### PR TITLE
fix(jambo): Fix required array fields without defaults

### DIFF
--- a/jambo/parser/array_type_parser.py
+++ b/jambo/parser/array_type_parser.py
@@ -35,10 +35,18 @@ class ArrayTypeParser(GenericTypeParser):
 
         mapped_properties = self.mappings_properties_builder(properties, **kwargs)
 
-        if "default" not in mapped_properties:
+        # Only set default_factory if the field is not required OR if there's an actual default
+        if not kwargs.get("required", False) and "default" not in mapped_properties:
             mapped_properties["default_factory"] = self._build_default_factory(
                 properties.get("default"), wrapper_type
             )
+        elif "default" in properties:
+            # If there's a default value specified, set the default_factory
+            mapped_properties["default_factory"] = self._build_default_factory(
+                properties["default"], wrapper_type
+            )
+            # Remove the regular default since we're using default_factory
+            mapped_properties.pop("default", None)
 
         return field_type, mapped_properties
 

--- a/tests/parser/test_array_type_parser.py
+++ b/tests/parser/test_array_type_parser.py
@@ -97,3 +97,18 @@ class TestArrayTypeParser(TestCase):
 
         with self.assertRaises(ValueError):
             parser.from_properties("placeholder", properties)
+
+    def test_array_parser_required_without_default(self):
+        """Regression test: Required array fields without defaults should be required"""
+        parser = ArrayTypeParser()
+
+        properties = {"items": {"type": "string"}}
+
+        # Test with required=True (should be required)
+        type_parsing, type_validator = parser.from_properties(
+            "test_array", properties, required=True
+        )
+
+        # Should NOT have default_factory when required and no default specified
+        self.assertNotIn("default_factory", type_validator)
+        self.assertNotIn("default", type_validator)


### PR DESCRIPTION
- Adds a test to ensure required array fields without defaults are enforced as required.
- Updates `ArrayTypeParser` to correctly handle `default_factory` for required fields and fields with defaults.