### PR TITLE
fix(jambo): Add binary string support

### DIFF
--- a/jambo/parser/string_type_parser.py
+++ b/jambo/parser/string_type_parser.py
@@ -27,6 +27,7 @@ class StringTypeParser(GenericTypeParser):
         "date": date,
         "time": time,
         "date-time": datetime,
+        "binary": bytes,
     }
 
     format_pattern_mapping = {

--- a/tests/parser/test_string_type_parser.py
+++ b/tests/parser/test_string_type_parser.py
@@ -197,3 +197,18 @@ class TestStringTypeParser(TestCase):
         type_parsing, type_validator = parser.from_properties("placeholder", properties)
 
         self.assertEqual(type_parsing, datetime)
+
+    def test_string_parser_with_byte_format(self):
+        parser = StringTypeParser()
+
+        properties = {
+            "type": "string",
+            "format": "binary",
+        }
+
+        type_parsing, type_validator = parser.from_properties("placeholder", properties)
+
+        self.assertEqual(type_parsing, bytes)
+
+        self.assertIn("json_schema_extra", type_validator)
+        self.assertEqual(type_validator["json_schema_extra"]["format"], "binary")


### PR DESCRIPTION
Add support for 'binary' format in StringTypeParser and associated test